### PR TITLE
fixed the segfault due to invalid returned address from basename()

### DIFF
--- a/ptrash.c
+++ b/ptrash.c
@@ -20,6 +20,7 @@
 
 #include <ptrash.h>
 #include <ptrashdb.h>
+#include <libgen.h>
 
 extern char *tdb;
 extern int opterr, optind;

--- a/ptrash.c
+++ b/ptrash.c
@@ -419,8 +419,8 @@ init_move (void)
     struct passwd *pw = NULL;
 
     pw = getpwuid (getuid ());
-    trsh = build_path (pw->pw_dir, ".local/share/.trash");
-    tdb  = build_path (trsh, ".trashdb");
+    trsh = build_path (pw->pw_dir, ".local/share/Trash/files");
+    tdb  = build_path (trsh, "../info/.trashdb");
     perm = S_IRWXU;
     if ((create_dir (trsh) == -1)
         || (open (tdb, O_CREAT, S_IRUSR|S_IWUSR) < 0))


### PR DESCRIPTION
1. First commit is to prevent segmentation fault due to basename()
2. Second commit fixes the paths.

Trashinfo file is yet to be created properly
